### PR TITLE
Renamed project to SQrLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "rusqlite"
+name = "sqrlite"
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rusqlite"
+name = "sqrlite"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::error::Error;
 use std::fmt;
 
-use rusqlite::db::Database;
+use sqrlite::db::Database;
 
 #[derive(Debug)]
 enum CMDError {


### PR DESCRIPTION
Renamed the project to `SQrLite` after finding out that `RuSQLite` was already taken.